### PR TITLE
 macOS: Implement EndpointSecurity Security Events Table 

### DIFF
--- a/osquery/events/darwin/endpointsecurity.cpp
+++ b/osquery/events/darwin/endpointsecurity.cpp
@@ -21,9 +21,14 @@ namespace osquery {
 
 DECLARE_bool(disable_endpointsecurity);
 DECLARE_bool(enable_es_authentication_events);
+DECLARE_bool(enable_es_network_events);
+DECLARE_bool(enable_es_memory_events);
+DECLARE_bool(enable_es_system_events);
+DECLARE_bool(enable_es_privilege_events);
 
 // Forward declarations
 class ESAuthenticationEventSubscriber;
+class ESSecurityEventSubscriber;
 
 REGISTER(EndpointSecurityPublisher, "event_publisher", "endpointsecurity")
 REGISTER(ESAuthenticationEventSubscriber,
@@ -142,7 +147,7 @@ void CoreEventRouter::routeEvent(const es_message_t* message,
       auth_ec->severity = "medium";
 
       // Generate a unique event ID
-      auth_ec->eid = generateEventId();
+      auth_ec->eid = generateUUID();
 
       // Get specific authentication event data (implemented in the subscriber)
       ESAuthenticationEventSubscriber::getAuthenticationEventData(message,
@@ -154,13 +159,46 @@ void CoreEventRouter::routeEvent(const es_message_t* message,
     break;
   }
 
-  // Currently we'll pass through for other event types
-  // In subsequent PRs, we'll implement specific handlers for each category
-  case ESEventCategory::PROCESS:
+  // Security events (network, memory, privilege, system)
   case ESEventCategory::NETWORK:
-  case ESEventCategory::FILE:
   case ESEventCategory::PRIVILEGE:
-  case ESEventCategory::SYSTEM:
+  case ESEventCategory::SYSTEM: {
+    if (FLAGS_enable_es_network_events || FLAGS_enable_es_memory_events ||
+        FLAGS_enable_es_system_events || FLAGS_enable_es_privilege_events) {
+      // Convert to security event context and populate specific fields
+      auto security_ec = std::make_shared<ESSecurityEventContext>();
+
+      // Copy base properties from the original context
+      security_ec->es_event = ec->es_event;
+      security_ec->version = ec->version;
+      security_ec->seq_num = ec->seq_num;
+      security_ec->global_seq_num = ec->global_seq_num;
+      security_ec->event_type = ec->event_type;
+      security_ec->pid = ec->pid;
+      security_ec->pidversion = ec->pidversion;
+      security_ec->path = ec->path;
+      security_ec->username = ec->username;
+
+      // Set category from categorization system
+      security_ec->category = getEventCategory(message->event_type);
+      security_ec->severity = getEventSeverity(message->event_type);
+
+      // Generate a unique event ID
+      security_ec->eid = generateUUID();
+
+      // Get specific security event data
+      ESSecurityEventSubscriber::getSecurityEventData(message, security_ec);
+
+      // Fire the event to security event subscribers
+      EventFactory::fire<EndpointSecurityPublisher>(security_ec);
+    }
+    break;
+  }
+
+  // Process events (handled by existing es_process_events table)
+  case ESEventCategory::PROCESS:
+  // File events (handled by existing es_process_file_events table)
+  case ESEventCategory::FILE:
   default:
     // If it's not a specialized event, just pass through to the original
     // publisher This maintains backward compatibility
@@ -238,6 +276,118 @@ void EndpointSecurityPublisher::handleMessage(const es_message_t* message) {
     return;
   }
 
+  // Handle authentication events directly
+  if (FLAGS_enable_es_authentication_events &&
+      isAuthenticationEvent(message->event_type)) {
+    auto auth_ec = std::make_shared<ESAuthenticationEventContext>();
+
+    // Initialize base properties
+    auth_ec->es_event = message->event_type;
+    auth_ec->version = message->version;
+    if (auth_ec->version >= 2) {
+      auth_ec->seq_num = message->seq_num;
+    }
+    if (auth_ec->version >= 4) {
+      auth_ec->global_seq_num = message->global_seq_num;
+    }
+
+    // Get process properties
+    getBaseProcessProperties(message->process, auth_ec);
+
+    // Set category and default severity
+    auth_ec->category = "authentication";
+    auth_ec->severity = "medium";
+
+    // Generate a unique event ID
+    auth_ec->eid = generateEventId();
+
+    // Get specific authentication event data
+    ESAuthenticationEventSubscriber::getAuthenticationEventData(message,
+                                                                auth_ec);
+
+    // Fire the event to authentication event subscribers
+    EventFactory::fire<EndpointSecurityPublisher>(auth_ec);
+
+    // For process-related events, also fire the standard process event for
+    // backward compatibility
+    if (message->event_type == ES_EVENT_TYPE_NOTIFY_EXEC ||
+        message->event_type == ES_EVENT_TYPE_NOTIFY_FORK ||
+        message->event_type == ES_EVENT_TYPE_NOTIFY_EXIT) {
+      // Continue with standard process event handling below
+    } else {
+      // For pure authentication events, we're done
+      return;
+    }
+  }
+
+  // Handle security events directly
+  bool is_security_event =
+      (FLAGS_enable_es_memory_events &&
+       (message->event_type == ES_EVENT_TYPE_NOTIFY_MMAP ||
+        message->event_type == ES_EVENT_TYPE_NOTIFY_MPROTECT)) ||
+      (FLAGS_enable_es_network_events &&
+       (message->event_type == ES_EVENT_TYPE_NOTIFY_SOCKET ||
+        message->event_type == ES_EVENT_TYPE_NOTIFY_CONNECT ||
+        message->event_type == ES_EVENT_TYPE_NOTIFY_BIND ||
+        message->event_type == ES_EVENT_TYPE_NOTIFY_LISTEN ||
+        message->event_type == ES_EVENT_TYPE_NOTIFY_ACCEPT ||
+        message->event_type == ES_EVENT_TYPE_NOTIFY_UIPC_BIND ||
+        message->event_type == ES_EVENT_TYPE_NOTIFY_UIPC_CONNECT)) ||
+      (FLAGS_enable_es_system_events &&
+       (message->event_type == ES_EVENT_TYPE_NOTIFY_KEXTLOAD ||
+        message->event_type == ES_EVENT_TYPE_NOTIFY_KEXTUNLOAD ||
+        message->event_type == ES_EVENT_TYPE_NOTIFY_SYSCTL)) ||
+      (FLAGS_enable_es_privilege_events &&
+       (message->event_type == ES_EVENT_TYPE_NOTIFY_SETUID ||
+        message->event_type == ES_EVENT_TYPE_NOTIFY_SETEUID ||
+        message->event_type == ES_EVENT_TYPE_NOTIFY_SETREUID ||
+        message->event_type == ES_EVENT_TYPE_NOTIFY_SETGID ||
+        message->event_type == ES_EVENT_TYPE_NOTIFY_SETEGID ||
+        message->event_type == ES_EVENT_TYPE_NOTIFY_SETREGID));
+
+  if (is_security_event) {
+    auto security_ec = std::make_shared<EndpointSecurityEventContext>();
+
+    // Initialize base properties
+    security_ec->es_event = message->event_type;
+    security_ec->version = message->version;
+    if (security_ec->version >= 2) {
+      security_ec->seq_num = message->seq_num;
+    }
+    if (security_ec->version >= 4) {
+      security_ec->global_seq_num = message->global_seq_num;
+    }
+
+    // Get process properties
+    getProcessProperties(message->process, security_ec);
+
+    // Get specific security event data
+    ESSecurityEventSubscriber::getSecurityEventData(message, security_ec);
+
+    // Fire the event to security event subscribers
+    EventFactory::fire<EndpointSecurityPublisher>(security_ec);
+
+    // For process-related events, also continue with standard process event
+    // handling (though security events generally aren't process events, this
+    // just ensures compatibility)
+    if (message->event_type == ES_EVENT_TYPE_NOTIFY_EXEC ||
+        message->event_type == ES_EVENT_TYPE_NOTIFY_FORK ||
+        message->event_type == ES_EVENT_TYPE_NOTIFY_EXIT) {
+      // Continue with standard process event handling below
+    } else {
+      // For pure security events, we're done
+      return;
+    }
+  }
+
+  // For file events or default handling
+  if (isFileEvent(message->event_type)) {
+    // Let the file event publisher handle these events
+    EndpointSecurityFileEventPublisher::handleMessage(message);
+    return;
+  }
+
+  // Standard process event handling for backward compatibility
   auto ec = createEventContext();
 
   ec->version = message->version;
@@ -297,10 +447,7 @@ void EndpointSecurityPublisher::handleMessage(const es_message_t* message) {
     break;
   }
 
-  // First route to specialized handlers through the CoreEventRouter
-  CoreEventRouter::routeEvent(message, ec);
-
-  // Then continue with the original event flow for backward compatibility
+  // Fire the standard process event
   EventFactory::fire<EndpointSecurityPublisher>(ec);
 }
 

--- a/osquery/events/darwin/endpointsecurity.h
+++ b/osquery/events/darwin/endpointsecurity.h
@@ -161,6 +161,39 @@ struct ESAuthenticationEventContext : public BaseESEventContext {
 using ESAuthenticationEventContextRef =
     std::shared_ptr<ESAuthenticationEventContext>;
 
+// Security Events subscription context and event context
+struct ESSecuritySubscriptionContext : public BaseESSubscriptionContext {};
+
+using ESSecuritySubscriptionContextRef =
+    std::shared_ptr<ESSecuritySubscriptionContext>;
+
+struct ESSecurityEventContext : public BaseESEventContext {
+  // Memory events
+  std::string address;
+  std::string protection;
+  int64_t size = 0;
+
+  // Network events
+  std::string local_address;
+  std::string remote_address;
+  int local_port = 0;
+  int remote_port = 0;
+  std::string family;
+  int protocol = 0;
+  std::string socket_type;
+
+  // System events
+  std::string kext_path;
+  std::string kext_version;
+  std::string kext_id;
+
+  // Privilege events
+  uid_t target_uid = 0;
+  gid_t target_gid = 0;
+};
+
+using ESSecurityEventContextRef = std::shared_ptr<ESSecurityEventContext>;
+
 // Core event category system
 // These help determine which subscriber should handle each event
 enum class ESEventCategory {
@@ -175,12 +208,11 @@ enum class ESEventCategory {
 // Function to determine the category of an event
 ESEventCategory categorizeESEvent(es_event_type_t event_type);
 
-// Core router for EndpointSecurity events
-class CoreEventRouter {
- public:
-  static void routeEvent(const es_message_t* message,
-                         const BaseESEventContextRef& ec);
-};
+// Helper function to check if an event type is related to authentication
+bool isAuthenticationEvent(es_event_type_t event_type);
+
+// Helper function to check if an event type is related to file operations
+bool isFileEvent(es_event_type_t event_type);
 
 class EndpointSecurityPublisher
     : public EventPublisher<EndpointSecuritySubscriptionContext,

--- a/osquery/events/darwin/es_utils.cpp
+++ b/osquery/events/darwin/es_utils.cpp
@@ -15,6 +15,7 @@
 #include <osquery/events/darwin/es_event_categories.h>
 #include <osquery/logger/logger.h>
 #include <pwd.h>
+#include <uuid/uuid.h>
 
 namespace osquery {
 
@@ -195,5 +196,8 @@ void appendQuotedString(std::ostream& out, std::string s, char delim) {
     out << s << delim;
   }
 }
+
+// generateUUID function is now defined as generateEventId in
+// endpointsecurity.cpp
 
 } // namespace osquery

--- a/osquery/events/darwin/es_utils.h
+++ b/osquery/events/darwin/es_utils.h
@@ -29,4 +29,6 @@ void getProcessProperties(const es_process_t* p,
 void getBaseProcessProperties(const es_process_t* p,
                               const BaseESEventContextRef& ec);
 void appendQuotedString(std::ostream& out, std::string s, char delim);
+
+// This function is now defined in endpointsecurity.cpp as generateEventId()
 } // namespace osquery

--- a/osquery/tables/events/CMakeLists.txt
+++ b/osquery/tables/events/CMakeLists.txt
@@ -46,6 +46,7 @@ function(generateOsqueryTablesEventsEventstable)
       darwin/es_process_events.cpp
       darwin/es_process_file_events.cpp
       darwin/es_authentication_events.cpp
+      darwin/es_security_events.cpp
       darwin/file_events.cpp
       darwin/hardware_events.cpp
       darwin/socket_events.cpp

--- a/osquery/tables/events/darwin/es_security_events.cpp
+++ b/osquery/tables/events/darwin/es_security_events.cpp
@@ -1,0 +1,582 @@
+/**
+ * Copyright (c) 2014-present, The osquery authors
+ *
+ * This source code is licensed as defined by the LICENSE file found in the
+ * root directory of this source tree.
+ *
+ * SPDX-License-Identifier: (Apache-2.0 OR GPL-2.0-only)
+ */
+
+#include <Availability.h>
+#include <EndpointSecurity/EndpointSecurity.h>
+#include <os/availability.h>
+
+#include <osquery/core/flags.h>
+#include <osquery/events/darwin/endpointsecurity.h>
+#include <osquery/events/darwin/es_event_categories.h>
+#include <osquery/events/darwin/es_utils.h>
+#include <osquery/events/events.h>
+#include <osquery/logger/logger.h>
+#include <osquery/registry/registry_factory.h>
+#include <osquery/sql/dynamic_table_row.h>
+#include <osquery/sql/sql.h>
+
+namespace osquery {
+
+// Define flags for controlling which event types are enabled
+FLAG(bool,
+     enable_es_network_events,
+     false,
+     "Enable EndpointSecurity network event monitoring");
+
+FLAG(bool,
+     enable_es_memory_events,
+     false,
+     "Enable EndpointSecurity memory protection event monitoring");
+
+FLAG(bool,
+     enable_es_system_events,
+     false,
+     "Enable EndpointSecurity system event monitoring");
+
+FLAG(bool,
+     enable_es_privilege_events,
+     false,
+     "Enable EndpointSecurity privilege event monitoring");
+
+// Forward declaration of the event subscriber class
+class ESSecurityEventSubscriber
+    : public EventSubscriber<EndpointSecurityPublisher> {
+ public:
+  ESSecurityEventSubscriber() {
+    setName("es_security_events");
+  }
+
+  Status init() override;
+  Status Callback(const EndpointSecurityEventContextRef& ec,
+                  const EndpointSecuritySubscriptionContextRef& sc);
+
+  // Handler to extract security event data from an ES message
+  static Status getSecurityEventData(const es_message_t* message,
+                                     EndpointSecurityEventContextRef& ec);
+};
+
+REGISTER(ESSecurityEventSubscriber, "event_subscriber", "es_security_events");
+
+/**
+ * @brief Initialize the SecurityEventSubscriber by creating subscriptions
+ *        to the appropriate event types based on OS version and flags.
+ */
+Status ESSecurityEventSubscriber::init() {
+  if (__builtin_available(macos 10.15, *)) {
+    auto sc = createSubscriptionContext();
+
+    // Memory events (macOS 11+)
+    if (FLAGS_enable_es_memory_events && __builtin_available(macos 11.0, *)) {
+      sc->es_event_subscriptions_.push_back(ES_EVENT_TYPE_NOTIFY_MMAP);
+      sc->es_event_subscriptions_.push_back(ES_EVENT_TYPE_NOTIFY_MPROTECT);
+    }
+
+    // Network events
+    if (FLAGS_enable_es_network_events && osSupportsNetworkEvents()) {
+      // Add Unix domain socket events (available on all supported macOS
+      // versions)
+      sc->es_event_subscriptions_.push_back(ES_EVENT_TYPE_NOTIFY_UIPC_BIND);
+      sc->es_event_subscriptions_.push_back(ES_EVENT_TYPE_NOTIFY_UIPC_CONNECT);
+
+      // On pre-macOS 15, we can add all network events
+      if (!(__builtin_available(macos 15.0, *))) {
+        sc->es_event_subscriptions_.push_back(ES_EVENT_TYPE_NOTIFY_SOCKET);
+        sc->es_event_subscriptions_.push_back(ES_EVENT_TYPE_NOTIFY_CONNECT);
+        sc->es_event_subscriptions_.push_back(ES_EVENT_TYPE_NOTIFY_BIND);
+        sc->es_event_subscriptions_.push_back(ES_EVENT_TYPE_NOTIFY_LISTEN);
+        sc->es_event_subscriptions_.push_back(ES_EVENT_TYPE_NOTIFY_ACCEPT);
+      }
+    }
+
+    // System events
+    if (FLAGS_enable_es_system_events) {
+      sc->es_event_subscriptions_.push_back(ES_EVENT_TYPE_NOTIFY_KEXTLOAD);
+      sc->es_event_subscriptions_.push_back(ES_EVENT_TYPE_NOTIFY_KEXTUNLOAD);
+
+      // Add sysctl event if not on macOS 15+
+      if (!(__builtin_available(macos 15.0, *))) {
+        sc->es_event_subscriptions_.push_back(ES_EVENT_TYPE_NOTIFY_SYSCTL);
+      }
+    }
+
+    // Privilege events
+    if (FLAGS_enable_es_privilege_events) {
+      sc->es_event_subscriptions_.push_back(ES_EVENT_TYPE_NOTIFY_SETUID);
+      sc->es_event_subscriptions_.push_back(ES_EVENT_TYPE_NOTIFY_SETEUID);
+      sc->es_event_subscriptions_.push_back(ES_EVENT_TYPE_NOTIFY_SETREUID);
+      sc->es_event_subscriptions_.push_back(ES_EVENT_TYPE_NOTIFY_SETGID);
+      sc->es_event_subscriptions_.push_back(ES_EVENT_TYPE_NOTIFY_SETEGID);
+      sc->es_event_subscriptions_.push_back(ES_EVENT_TYPE_NOTIFY_SETREGID);
+    }
+
+    subscribe(&ESSecurityEventSubscriber::Callback, sc);
+
+    return Status::success();
+  } else {
+    return Status::failure(1, "Only available on macOS 10.15 and higher");
+  }
+}
+
+/**
+ * @brief Process security events from EndpointSecurity and store them.
+ *
+ * @param message Pointer to the EndpointSecurity message
+ * @param ec Reference to the event context to populate
+ * @return Status indicating success or failure
+ */
+Status ESSecurityEventSubscriber::getSecurityEventData(
+    const es_message_t* message, EndpointSecurityEventContextRef& ec) {
+  if (message == nullptr || ec == nullptr) {
+    return Status::failure(1, "Invalid message or context");
+  }
+
+  // Fill in common event metadata
+  ec->es_event = message->event_type;
+  auto event_time = static_cast<long long>(message->time.tv_sec);
+  ec->time = event_time;
+  getBaseProcessProperties(message->process, ec);
+
+  // Get category, severity, and name from es_event_categories
+  ec->category = getEventCategory(message->event_type);
+  ec->severity = getEventSeverity(message->event_type);
+  ec->description = getEventName(message->event_type);
+  ec->eid = generateEventId(); // Create a unique ID for this event
+
+  // Default initialize network fields
+  ec->local_address = "";
+  ec->remote_address = "";
+  ec->local_port = 0;
+  ec->remote_port = 0;
+
+  // Default initialize memory fields
+  ec->address = "";
+  ec->protection = "";
+  ec->size = 0;
+
+  // Default initialize kext fields
+  ec->kext_path = "";
+  ec->kext_version = "";
+  ec->kext_id = "";
+
+  // Process different security event types
+  switch (message->event_type) {
+  // Memory protection events
+  case ES_EVENT_TYPE_NOTIFY_MMAP: {
+    if (__builtin_available(macos 11.0, *)) {
+      ec->event_type = "mmap";
+
+      // Get memory address as string
+      std::stringstream ss;
+      ss << std::hex << message->event.mmap->address;
+      ec->address = "0x" + ss.str();
+
+      // Get memory protection flags
+      std::string prot = "";
+      if (message->event.mmap->protection & PROT_READ) {
+        prot += "r";
+      }
+      if (message->event.mmap->protection & PROT_WRITE) {
+        prot += "w";
+      }
+      if (message->event.mmap->protection & PROT_EXEC) {
+        prot += "x";
+      }
+      ec->protection = prot;
+
+      // Get memory size
+      ec->size = static_cast<int64_t>(message->event.mmap->size);
+    }
+    break;
+  }
+
+  case ES_EVENT_TYPE_NOTIFY_MPROTECT: {
+    if (__builtin_available(macos 11.0, *)) {
+      ec->event_type = "mprotect";
+
+      // Get memory address as string
+      std::stringstream ss;
+      ss << std::hex << message->event.mprotect->address;
+      ec->address = "0x" + ss.str();
+
+      // Get memory protection flags
+      std::string prot = "";
+      if (message->event.mprotect->protection & PROT_READ) {
+        prot += "r";
+      }
+      if (message->event.mprotect->protection & PROT_WRITE) {
+        prot += "w";
+      }
+      if (message->event.mprotect->protection & PROT_EXEC) {
+        prot += "x";
+      }
+      ec->protection = prot;
+
+      // Get memory size
+      ec->size = static_cast<int64_t>(message->event.mprotect->size);
+    }
+    break;
+  }
+
+  // Network events
+  case ES_EVENT_TYPE_NOTIFY_SOCKET: {
+    if (!(__builtin_available(macos 15.0, *))) {
+      ec->event_type = "socket";
+
+      // Get socket family
+      int domain = message->event.socket->domain;
+      switch (domain) {
+      case AF_INET:
+        ec->family = "IPv4";
+        break;
+      case AF_INET6:
+        ec->family = "IPv6";
+        break;
+      case AF_UNIX:
+        ec->family = "UNIX";
+        break;
+      default:
+        ec->family = std::to_string(domain);
+        break;
+      }
+
+      // Get socket type
+      int type = message->event.socket->type;
+      switch (type) {
+      case SOCK_STREAM:
+        ec->socket_type = "stream";
+        break;
+      case SOCK_DGRAM:
+        ec->socket_type = "dgram";
+        break;
+      case SOCK_RAW:
+        ec->socket_type = "raw";
+        break;
+      default:
+        ec->socket_type = std::to_string(type);
+        break;
+      }
+
+      // Get protocol
+      ec->protocol = message->event.socket->protocol;
+    }
+    break;
+  }
+
+  case ES_EVENT_TYPE_NOTIFY_CONNECT: {
+    if (!(__builtin_available(macos 15.0, *))) {
+      ec->event_type = "connect";
+
+      // Attempt to extract remote address info from sockaddr
+      if (message->event.connect->remote->sa_family == AF_INET) {
+        const struct sockaddr_in* addr =
+            reinterpret_cast<const struct sockaddr_in*>(
+                message->event.connect->remote);
+        char ip_str[INET_ADDRSTRLEN];
+        inet_ntop(AF_INET, &addr->sin_addr, ip_str, INET_ADDRSTRLEN);
+        ec->remote_address = ip_str;
+        ec->remote_port = ntohs(addr->sin_port);
+        ec->family = "IPv4";
+      } else if (message->event.connect->remote->sa_family == AF_INET6) {
+        const struct sockaddr_in6* addr =
+            reinterpret_cast<const struct sockaddr_in6*>(
+                message->event.connect->remote);
+        char ip_str[INET6_ADDRSTRLEN];
+        inet_ntop(AF_INET6, &addr->sin6_addr, ip_str, INET6_ADDRSTRLEN);
+        ec->remote_address = ip_str;
+        ec->remote_port = ntohs(addr->sin6_port);
+        ec->family = "IPv6";
+      } else if (message->event.connect->remote->sa_family == AF_UNIX) {
+        ec->family = "UNIX";
+        // Unix domain sockets don't have IPs or ports
+      }
+    }
+    break;
+  }
+
+  case ES_EVENT_TYPE_NOTIFY_BIND: {
+    if (!(__builtin_available(macos 15.0, *))) {
+      ec->event_type = "bind";
+
+      // Attempt to extract local address info from sockaddr
+      if (message->event.bind->local->sa_family == AF_INET) {
+        const struct sockaddr_in* addr =
+            reinterpret_cast<const struct sockaddr_in*>(
+                message->event.bind->local);
+        char ip_str[INET_ADDRSTRLEN];
+        inet_ntop(AF_INET, &addr->sin_addr, ip_str, INET_ADDRSTRLEN);
+        ec->local_address = ip_str;
+        ec->local_port = ntohs(addr->sin_port);
+        ec->family = "IPv4";
+      } else if (message->event.bind->local->sa_family == AF_INET6) {
+        const struct sockaddr_in6* addr =
+            reinterpret_cast<const struct sockaddr_in6*>(
+                message->event.bind->local);
+        char ip_str[INET6_ADDRSTRLEN];
+        inet_ntop(AF_INET6, &addr->sin6_addr, ip_str, INET6_ADDRSTRLEN);
+        ec->local_address = ip_str;
+        ec->local_port = ntohs(addr->sin6_port);
+        ec->family = "IPv6";
+      } else if (message->event.bind->local->sa_family == AF_UNIX) {
+        ec->family = "UNIX";
+        // Unix domain sockets don't have IPs or ports
+      }
+    }
+    break;
+  }
+
+  case ES_EVENT_TYPE_NOTIFY_LISTEN: {
+    if (!(__builtin_available(macos 15.0, *))) {
+      ec->event_type = "listen";
+    }
+    break;
+  }
+
+  case ES_EVENT_TYPE_NOTIFY_ACCEPT: {
+    if (!(__builtin_available(macos 15.0, *))) {
+      ec->event_type = "accept";
+    }
+    break;
+  }
+
+  case ES_EVENT_TYPE_NOTIFY_UIPC_BIND: {
+    ec->event_type = "uipc_bind";
+    ec->family = "UNIX";
+
+    // Try to get the Unix domain socket path
+    if (message->event.uipc_bind->dir != nullptr &&
+        message->event.uipc_bind->dir->path.length > 0) {
+      const auto& path_token = message->event.uipc_bind->dir->path;
+      if (path_token.length > 0 && path_token.data != nullptr) {
+        ec->local_address = std::string(path_token.data, path_token.length);
+      }
+    }
+    break;
+  }
+
+  case ES_EVENT_TYPE_NOTIFY_UIPC_CONNECT: {
+    ec->event_type = "uipc_connect";
+    ec->family = "UNIX";
+
+    // Try to get the Unix domain socket path
+    if (message->event.uipc_connect->dir != nullptr &&
+        message->event.uipc_connect->dir->path.length > 0) {
+      const auto& path_token = message->event.uipc_connect->dir->path;
+      if (path_token.length > 0 && path_token.data != nullptr) {
+        ec->remote_address = std::string(path_token.data, path_token.length);
+      }
+    }
+    break;
+  }
+
+  // Kernel extension events
+  case ES_EVENT_TYPE_NOTIFY_KEXTLOAD: {
+    ec->event_type = "kextload";
+
+    // Extract kext information
+    if (message->event.kextload->identifier.length > 0 &&
+        message->event.kextload->identifier.data != nullptr) {
+      ec->kext_id = std::string(message->event.kextload->identifier.data,
+                                message->event.kextload->identifier.length);
+    }
+
+    // Version may not be available in all versions of the API
+    ec->kext_version = "";
+
+    // Get the kext path
+    if (message->event.kextload->kext != nullptr &&
+        message->event.kextload->kext->path.length > 0) {
+      const auto& path_token = message->event.kextload->kext->path;
+      if (path_token.length > 0 && path_token.data != nullptr) {
+        ec->kext_path = std::string(path_token.data, path_token.length);
+      }
+    }
+    break;
+  }
+
+  case ES_EVENT_TYPE_NOTIFY_KEXTUNLOAD: {
+    ec->event_type = "kextunload";
+
+    // Extract kext information
+    if (message->event.kextunload->identifier.length > 0 &&
+        message->event.kextunload->identifier.data != nullptr) {
+      ec->kext_id = std::string(message->event.kextunload->identifier.data,
+                                message->event.kextunload->identifier.length);
+    }
+    break;
+  }
+
+  case ES_EVENT_TYPE_NOTIFY_SYSCTL: {
+    if (!(__builtin_available(macos 15.0, *))) {
+      ec->event_type = "sysctl";
+      // Add any sysctl-specific information here
+    }
+    break;
+  }
+
+  // Privilege events
+  case ES_EVENT_TYPE_NOTIFY_SETUID: {
+    ec->event_type = "setuid";
+
+    // Handle macOS version differences for uid/euid field naming
+    if (useEuidFieldsForSetters() && __builtin_available(macos 12.0, *)) {
+      ec->target_uid = message->event.setuid.euid;
+    } else {
+      ec->target_uid = message->event.setuid.uid;
+    }
+    break;
+  }
+
+  case ES_EVENT_TYPE_NOTIFY_SETEUID: {
+    ec->event_type = "seteuid";
+
+    // Handle macOS version differences for uid/euid field naming
+    if (useEuidFieldsForSetters() && __builtin_available(macos 12.0, *)) {
+      ec->target_uid = message->event.seteuid.euid;
+    } else {
+      ec->target_uid = message->event.seteuid.uid;
+    }
+    break;
+  }
+
+  case ES_EVENT_TYPE_NOTIFY_SETREUID: {
+    ec->event_type = "setreuid";
+
+    // We'll store the effective UID as the target
+    if (useEuidFieldsForSetters() && __builtin_available(macos 12.0, *)) {
+      ec->target_uid = message->event.setreuid.euid;
+    } else {
+      ec->target_uid = message->event.setreuid.uid;
+    }
+    break;
+  }
+
+  case ES_EVENT_TYPE_NOTIFY_SETGID: {
+    ec->event_type = "setgid";
+
+    // Handle macOS version differences for gid/egid field naming
+    if (useEuidFieldsForSetters() && __builtin_available(macos 12.0, *)) {
+      ec->target_gid = message->event.setgid.egid;
+    } else {
+      ec->target_gid = message->event.setgid.gid;
+    }
+    break;
+  }
+
+  case ES_EVENT_TYPE_NOTIFY_SETEGID: {
+    ec->event_type = "setegid";
+
+    // Handle macOS version differences for gid/egid field naming
+    if (useEuidFieldsForSetters() && __builtin_available(macos 12.0, *)) {
+      ec->target_gid = message->event.setegid.egid;
+    } else {
+      ec->target_gid = message->event.setegid.gid;
+    }
+    break;
+  }
+
+  case ES_EVENT_TYPE_NOTIFY_SETREGID: {
+    ec->event_type = "setregid";
+
+    // We'll store the effective GID as the target
+    if (useEuidFieldsForSetters() && __builtin_available(macos 12.0, *)) {
+      ec->target_gid = message->event.setregid.egid;
+    } else {
+      ec->target_gid = message->event.setregid.gid;
+    }
+    break;
+  }
+
+  default:
+    return Status::failure(1, "Unsupported security event type");
+  }
+
+  return Status::success();
+}
+
+Status ESSecurityEventSubscriber::Callback(
+    const EndpointSecurityEventContextRef& ec,
+    const EndpointSecuritySubscriptionContextRef& sc) {
+  // Process security event
+  Row r;
+
+  r["time"] = BIGINT(ec->time);
+  r["eid"] = SQL_TEXT(ec->eid);
+  r["event_type"] = SQL_TEXT(ec->event_type);
+  r["category"] = SQL_TEXT(ec->category);
+  r["severity"] = SQL_TEXT(ec->severity);
+  r["pid"] = BIGINT(ec->pid);
+  r["parent"] = BIGINT(ec->parent);
+  r["path"] = SQL_TEXT(ec->path);
+  r["username"] = SQL_TEXT(ec->username);
+  r["description"] = SQL_TEXT(ec->description);
+
+  // Memory events fields
+  r["address"] = SQL_TEXT(ec->address);
+  r["protection"] = SQL_TEXT(ec->protection);
+  r["size"] = BIGINT(ec->size);
+
+  // Network events fields
+  r["local_address"] = SQL_TEXT(ec->local_address);
+  r["remote_address"] = SQL_TEXT(ec->remote_address);
+  r["local_port"] = INTEGER(ec->local_port);
+  r["remote_port"] = INTEGER(ec->remote_port);
+  r["family"] = SQL_TEXT(ec->family);
+  r["protocol"] = INTEGER(ec->protocol);
+  r["socket_type"] = SQL_TEXT(ec->socket_type);
+
+  // System events fields
+  r["kext_path"] = SQL_TEXT(ec->kext_path);
+  r["kext_version"] = SQL_TEXT(ec->kext_version);
+  r["kext_id"] = SQL_TEXT(ec->kext_id);
+
+  // Privilege events fields
+  r["uid"] = BIGINT(ec->uid);
+  r["euid"] = BIGINT(ec->euid);
+  r["gid"] = BIGINT(ec->gid);
+  r["egid"] = BIGINT(ec->egid);
+  r["target_uid"] = BIGINT(ec->target_uid);
+  r["target_gid"] = BIGINT(ec->target_gid);
+
+  // Add the row to our subscription context
+  sc->row_list.push_back(r);
+  return Status::success();
+}
+
+namespace tables {
+
+class ESSecurityEvents {
+ public:
+  static QueryData genTable(QueryContext& context) {
+    QueryData results;
+    auto es_security_events =
+        EventFactory::getEventSubscriber("es_security_events");
+    if (es_security_events != nullptr) {
+      auto subscriber =
+          dynamic_cast<ESSecurityEventSubscriber*>(es_security_events.get());
+      if (subscriber != nullptr) {
+        // Get time ranges to query
+        auto time_constraint = context.constraints["time"].getAll(EQUALS);
+
+        // Get all batched events within time range
+        if (context.constraints["time"].exists(EQUALS)) {
+          for (const auto& time : time_constraint) {
+            subscriber->getEvents(time, results);
+          }
+        } else {
+          // If no time constraint, get all events in the buffer
+          subscriber->getEvents(results);
+        }
+      }
+    }
+    return results;
+  }
+};
+
+} // namespace tables
+} // namespace osquery

--- a/osquery/tables/events/tests/CMakeLists.txt
+++ b/osquery/tables/events/tests/CMakeLists.txt
@@ -21,6 +21,8 @@ function(osqueryTablesEventsTestsMain)
     generateOsqueryTablesEventsTestsPowershelleventstestsTest()
     generateOsqueryTablesEventsTestsWindowseventstestsTest()
     generateOsqueryTablesEventsTestsETWtestsTest()
+  elseif(DEFINED PLATFORM_MACOS)
+    generateOsqueryTablesEventsTestsESSecurityEventsTest()
   endif()
 endfunction()
 
@@ -161,6 +163,24 @@ function(generateOsqueryTablesEventsTestsWindowseventstestsTest)
     osquery_cxx_settings
     osquery_core
     osquery_database
+    osquery_extensions
+    osquery_extensions_implthrift
+    osquery_logger
+    osquery_registry
+    osquery_tables_events_eventstable
+    tests_helper
+    thirdparty_googletest
+  )
+endfunction()
+
+function(generateOsqueryTablesEventsTestsESSecurityEventsTest)
+  add_osquery_executable(osquery_tables_events_tests_essecurityevents-test darwin/es_security_events_tests.cpp)
+
+  target_link_libraries(osquery_tables_events_tests_essecurityevents-test PRIVATE
+    osquery_cxx_settings
+    osquery_core
+    osquery_database
+    osquery_events
     osquery_extensions
     osquery_extensions_implthrift
     osquery_logger

--- a/osquery/tables/events/tests/darwin/es_security_events_tests.cpp
+++ b/osquery/tables/events/tests/darwin/es_security_events_tests.cpp
@@ -1,0 +1,202 @@
+/**
+ * Copyright (c) 2014-present, The osquery authors
+ *
+ * This source code is licensed as defined by the LICENSE file found in the
+ * root directory of this source tree.
+ *
+ * SPDX-License-Identifier: (Apache-2.0 OR GPL-2.0-only)
+ */
+
+#include <gtest/gtest.h>
+
+#include <osquery/events/darwin/endpointsecurity.h>
+#include <osquery/events/darwin/es_event_categories.h>
+#include <osquery/tables/events/darwin/es_security_events.cpp>
+
+namespace osquery {
+namespace {
+
+class ESSecurityEventsTests : public testing::Test {
+ protected:
+  void SetUp() override {
+    // Create a subscription context for testing
+    sc_ = std::make_shared<EndpointSecuritySubscriptionContext>();
+
+    // Create a message for testing (a simplified stub)
+    message_ = {};
+    process_ = {};
+
+    // Set up basic message structure
+    message_.process = &process_;
+    message_.time.tv_sec = 1234567890;
+    message_.version = 4;
+    message_.global_seq_num = 12345;
+  }
+
+  void TearDown() override {
+    // Clean up
+  }
+
+  // Stub implementation of structures
+  EndpointSecuritySubscriptionContextRef sc_;
+  es_message_t message_;
+  es_process_t process_;
+};
+
+TEST_F(ESSecurityEventsTests, CallbackTest) {
+  // Create a security event context with basic information
+  auto ec = std::make_shared<EndpointSecurityEventContext>();
+  ec->event_type = "test_event";
+  ec->category = "memory";
+  ec->severity = "high";
+  ec->eid = "test-uuid-1234";
+  ec->pid = 1234;
+  ec->path = "/usr/bin/test";
+  ec->description = "Test security event";
+
+  // For memory events
+  ec->address = "0x12345678";
+  ec->protection = "rwx";
+  ec->size = 4096;
+
+  // Call the callback
+  ESSecurityEventSubscriber subscriber;
+  auto status = subscriber.Callback(ec, sc_);
+
+  // Verify the callback was successful
+  EXPECT_TRUE(status.ok());
+
+  // Verify row was added to the subscription context
+  EXPECT_EQ(sc_->row_list.size(), 1U);
+
+  // Verify row contents
+  if (!sc_->row_list.empty()) {
+    auto row = sc_->row_list[0];
+
+    EXPECT_EQ(row["event_type"], "test_event");
+    EXPECT_EQ(row["category"], "memory");
+    EXPECT_EQ(row["severity"], "high");
+    EXPECT_EQ(row["eid"], "test-uuid-1234");
+    EXPECT_EQ(row["pid"], "1234");
+    EXPECT_EQ(row["path"], "/usr/bin/test");
+    EXPECT_EQ(row["description"], "Test security event");
+
+    // Check memory-specific fields
+    EXPECT_EQ(row["address"], "0x12345678");
+    EXPECT_EQ(row["protection"], "rwx");
+    EXPECT_EQ(row["size"], "4096");
+  }
+}
+
+TEST_F(ESSecurityEventsTests, GetSecurityEventDataTest) {
+  if (__builtin_available(macos 10.15, *)) {
+    // Only run the test on macOS 10.15 or newer
+
+    auto ec = std::make_shared<EndpointSecurityEventContext>();
+
+    // Test memory event handling
+    if (__builtin_available(macos 11.0, *)) {
+      // Memory events (mmap, mprotect)
+      message_.event_type = ES_EVENT_TYPE_NOTIFY_MMAP;
+
+      // Stub for mmap event
+      es_event_mmap_t mmap_event = {};
+      mmap_event.protection = PROT_READ | PROT_WRITE | PROT_EXEC;
+      mmap_event.size = 4096;
+      mmap_event.address = reinterpret_cast<void*>(0x12345678);
+      message_.event.mmap = &mmap_event;
+
+      // Get security event data
+      auto status =
+          ESSecurityEventSubscriber::getSecurityEventData(&message_, ec);
+      EXPECT_TRUE(status.ok());
+
+      // Verify event data
+      EXPECT_EQ(ec->event_type, "mmap");
+      EXPECT_EQ(ec->protection, "rwx");
+      EXPECT_EQ(ec->size, 4096);
+      EXPECT_NE(ec->address.find("0x"), std::string::npos);
+    }
+
+    // Test privilage event handling
+    message_.event_type = ES_EVENT_TYPE_NOTIFY_SETUID;
+
+    // Stub for setuid event
+    es_event_setuid_t setuid_event = {};
+    if (__builtin_available(macos 12.0, *)) {
+      setuid_event.euid = 500;
+    } else {
+      setuid_event.uid = 500;
+    }
+    message_.event.setuid = setuid_event;
+
+    // Get security event data
+    auto status =
+        ESSecurityEventSubscriber::getSecurityEventData(&message_, ec);
+    EXPECT_TRUE(status.ok());
+
+    // Verify event data
+    EXPECT_EQ(ec->event_type, "setuid");
+    EXPECT_EQ(ec->target_uid, 500);
+  }
+}
+
+TEST_F(ESSecurityEventsTests, InitTest) {
+  if (__builtin_available(macos 10.15, *)) {
+    // Test initialization of the subscriber
+    ESSecurityEventSubscriber subscriber;
+    auto status = subscriber.init();
+
+    // Always expect success on macOS 10.15+
+    EXPECT_TRUE(status.ok());
+  }
+}
+
+// Additional helper function tests
+
+TEST_F(ESSecurityEventsTests, generateEventIdTest) {
+  // Test UUID generation
+  std::string uuid1 = generateEventId();
+  std::string uuid2 = generateEventId();
+
+  // Each UUID should be 36 characters (including hyphens)
+  EXPECT_EQ(uuid1.length(), 36U);
+  EXPECT_EQ(uuid2.length(), 36U);
+
+  // UUIDs should be unique
+  EXPECT_NE(uuid1, uuid2);
+
+  // Check for proper UUID format (8-4-4-4-12 hex digits)
+  EXPECT_TRUE(std::regex_match(
+      uuid1,
+      std::regex(
+          "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}")));
+}
+
+TEST_F(ESSecurityEventsTests, isFileEventTest) {
+  // Test file event detection
+  EXPECT_TRUE(isFileEvent(ES_EVENT_TYPE_NOTIFY_CREATE));
+  EXPECT_TRUE(isFileEvent(ES_EVENT_TYPE_NOTIFY_RENAME));
+  EXPECT_TRUE(isFileEvent(ES_EVENT_TYPE_NOTIFY_CHMOD));
+
+  // Test non-file events
+  EXPECT_FALSE(isFileEvent(ES_EVENT_TYPE_NOTIFY_EXEC));
+  EXPECT_FALSE(isFileEvent(ES_EVENT_TYPE_NOTIFY_FORK));
+  EXPECT_FALSE(isFileEvent(ES_EVENT_TYPE_NOTIFY_SOCKET));
+}
+
+TEST_F(ESSecurityEventsTests, isAuthenticationEventTest) {
+  // Test authentication event detection
+  EXPECT_TRUE(isAuthenticationEvent(ES_EVENT_TYPE_NOTIFY_AUTHENTICATION));
+  EXPECT_TRUE(isAuthenticationEvent(ES_EVENT_TYPE_NOTIFY_OPENSSH_LOGIN));
+  EXPECT_TRUE(isAuthenticationEvent(ES_EVENT_TYPE_NOTIFY_SU));
+  EXPECT_TRUE(isAuthenticationEvent(ES_EVENT_TYPE_NOTIFY_SUDO));
+
+  // Test non-authentication events
+  EXPECT_FALSE(isAuthenticationEvent(ES_EVENT_TYPE_NOTIFY_EXEC));
+  EXPECT_FALSE(isAuthenticationEvent(ES_EVENT_TYPE_NOTIFY_SOCKET));
+  EXPECT_FALSE(isAuthenticationEvent(ES_EVENT_TYPE_NOTIFY_MMAP));
+}
+
+} // namespace
+} // namespace osquery

--- a/packs/macos-endpoint-security.conf
+++ b/packs/macos-endpoint-security.conf
@@ -43,6 +43,36 @@
       "interval": 300,
       "description": "Screen sharing sessions from EndpointSecurity.",
       "removed": false
+    },
+    "es_security_high_severity": {
+      "query": "SELECT time, event_type, category, description, pid, path, username FROM es_security_events WHERE severity = 'high' ORDER BY time DESC;",
+      "interval": 300,
+      "description": "High severity security events from EndpointSecurity.",
+      "removed": false
+    },
+    "es_security_memory_protection": {
+      "query": "SELECT time, event_type, pid, path, username, address, size, protection FROM es_security_events WHERE category = 'memory' ORDER BY time DESC;",
+      "interval": 300,
+      "description": "Memory protection events from EndpointSecurity.",
+      "removed": false
+    },
+    "es_security_network_events": {
+      "query": "SELECT time, event_type, pid, path, username, family, local_address, remote_address, local_port, remote_port FROM es_security_events WHERE category = 'network' ORDER BY time DESC;",
+      "interval": 300,
+      "description": "Network events from EndpointSecurity.",
+      "removed": false
+    },
+    "es_security_kext_events": {
+      "query": "SELECT time, event_type, pid, path, username, kext_path, kext_id, kext_version FROM es_security_events WHERE event_type IN ('kextload', 'kextunload') ORDER BY time DESC;",
+      "interval": 300,
+      "description": "Kernel extension load/unload events from EndpointSecurity.",
+      "removed": false
+    },
+    "es_security_privilege_escalation": {
+      "query": "SELECT time, event_type, pid, path, username, uid, euid, target_uid FROM es_security_events WHERE category = 'privilege' ORDER BY time DESC;",
+      "interval": 300,
+      "description": "Privilege escalation events from EndpointSecurity.",
+      "removed": false
     }
   }
 }

--- a/specs/CMakeLists.txt
+++ b/specs/CMakeLists.txt
@@ -106,6 +106,7 @@ function(generateNativeTables)
     "darwin/es_process_events.table:macos"
     "darwin/es_process_file_events.table:macos"
     "darwin/es_authentication_events.table:macos"
+    "darwin/es_security_events.table:macos"
     "darwin/event_taps.table:macos"
     "darwin/fan_speed_sensors.table:macos"
     "darwin/gatekeeper.table:macos"

--- a/specs/darwin/es_security_events.table
+++ b/specs/darwin/es_security_events.table
@@ -1,0 +1,53 @@
+table_name("es_security_events")
+description("EndpointSecurity security events from the Apple Endpoint Security Framework.")
+schema([
+    Column("time", BIGINT, "Time of the event"),
+    Column("eid", TEXT, "Event ID"),
+    Column("event_type", TEXT, "Event type"),
+    Column("category", TEXT, "Event category (network, memory, system, privilege)"),
+    Column("severity", TEXT, "Event severity (high, medium, low)"),
+    Column("pid", BIGINT, "Process ID"),
+    Column("parent", BIGINT, "Parent process ID"),
+    Column("path", TEXT, "Path of executed file"),
+    Column("username", TEXT, "Username of the process"),
+
+    # Memory events
+    Column("address", TEXT, "Memory address", additional=True),
+    Column("protection", TEXT, "Memory protection (r/w/x) flags", additional=True),
+    Column("size", BIGINT, "Size of memory region", additional=True),
+    
+    # Network events
+    Column("local_address", TEXT, "Local network address", additional=True),
+    Column("remote_address", TEXT, "Remote network address", additional=True),
+    Column("local_port", INTEGER, "Local network port", additional=True),
+    Column("remote_port", INTEGER, "Remote network port", additional=True),
+    Column("family", TEXT, "Network family (IPv4, IPv6, UNIX)", additional=True),
+    Column("protocol", INTEGER, "Network protocol", additional=True),
+    Column("socket_type", TEXT, "Socket type (stream, dgram, etc.)", additional=True),
+    
+    # System events
+    Column("kext_path", TEXT, "Path of loaded/unloaded kernel extension", additional=True),
+    Column("kext_version", TEXT, "Version of kernel extension", additional=True),
+    Column("kext_id", TEXT, "Bundle identifier of kernel extension", additional=True),
+    
+    # Privilege events
+    Column("uid", BIGINT, "User ID", additional=True),
+    Column("euid", BIGINT, "Effective user ID", additional=True),
+    Column("gid", BIGINT, "Group ID", additional=True),
+    Column("egid", BIGINT, "Effective group ID", additional=True),
+    Column("target_uid", BIGINT, "Target user ID for privilege changes", additional=True),
+    Column("target_gid", BIGINT, "Target group ID for privilege changes", additional=True),
+    
+    # General metadata
+    Column("description", TEXT, "Description of the event"),
+    Column("metadata", TEXT, "Additional event-specific metadata in JSON format", additional=True),
+])
+attributes(cacheable=False)
+implementation("es_security_events@ESSecurityEvents::genTable")
+examples([
+  "SELECT * FROM es_security_events WHERE severity='high' ORDER BY time DESC LIMIT 10",
+  "SELECT * FROM es_security_events WHERE category='network' AND event_type='connect' ORDER BY time DESC LIMIT 10",
+  "SELECT * FROM es_security_events WHERE category='memory' AND event_type='mprotect' AND pid=1234",
+  "SELECT * FROM es_security_events WHERE category='system' AND event_type LIKE 'kext%'",
+  "SELECT * FROM es_security_events WHERE category='privilege' AND JSON_EXTRACT(metadata, '$.status') = 'success'"
+])


### PR DESCRIPTION
macOS: Implement ES Security Events Table
This commit implements the the EndpointSecurity event tables, focused on security events. It adds support for memory protection, network, system, and privilege events.

The implementation includes:
- New es_security_events table and schema
- Event handlers for memory events (mmap, mprotect)
- Event handlers for network events (socket, connect, bind, listen, etc.)
- Event handlers for system events (kextload, kextunload, sysctl)
- Event handlers for privilege events (setuid, seteuid, etc.)
- macOS version compatibility for events across 10.15-15.0
- Example queries in the macos-endpoint-security pack

This addresses Phase 2 of the EndpointSecurity modularization plan.